### PR TITLE
Don't attach event handlers in ready event

### DIFF
--- a/src/discord/index.js
+++ b/src/discord/index.js
@@ -24,8 +24,8 @@ client.on('messageCreate', (message) => {
 	handler(message, () => {
 		if (message.mss.command && message.mss.admin >= commands[message.mss.command].admin) {
 			commands[message.mss.command].command(message);
-    }
-  });
+		}
+    });
 });
 
 client.on('userUpdate', (user, old) => {

--- a/src/discord/index.js
+++ b/src/discord/index.js
@@ -17,24 +17,26 @@ client.on('ready', () => {
 	module.exports.guild = client.guilds.get(config.get('discord').guild);
 	module.exports.channel = module.exports.guild.channels.get(config.get('discord').channel);
 	module.exports.ready = true;
+});
 
-	client.on('messageCreate', (message) => {
-		handler(message, () => {
-			if (message.mss.command && message.mss.admin >= commands[message.mss.command].admin) {
-				commands[message.mss.command].command(message);
-			}
-		});
-	});
-
-	client.on('userUpdate', (user, old) => {
-		if (user && old && (user.avatar !== old.avatar) {
-			r.table('bots')
-				.get(user.id)
-				.update({
-					avatar: user.avatar
-				});
+client.on('messageCreate', (message) => {
+	if (!module.exports.ready) return;
+	handler(message, () => {
+		if (message.mss.command && message.mss.admin >= commands[message.mss.command].admin) {
+			commands[message.mss.command].command(message);
 		}
 	});
+});
+
+client.on('userUpdate', (user, old) => {
+	if (!module.exports.ready) return;
+	if (user && old && (user.avatar !== old.avatar)) {
+		r.table('bots')
+			.get(user.id)
+			.update({
+				avatar: user.avatar
+			});
+	}
 });
 
 client.connect();


### PR DESCRIPTION
**Reason:**
When Discord has a hiccup or the bot needs to reconnect, the ready event will be fired again thus attaching a second event handler and double-posting and so forth.